### PR TITLE
Properly handle encoded params, support 2 legged OAuth, make OAuth a global class

### DIFF
--- a/OAuth/src/classes/OAuth.cls
+++ b/OAuth/src/classes/OAuth.cls
@@ -1,4 +1,4 @@
-public class OAuth {
+global class OAuth {
 
 	private OAuthService__c service;
 	private String token;

--- a/OAuth/src/classes/OAuth.cls
+++ b/OAuth/src/classes/OAuth.cls
@@ -181,9 +181,24 @@ public class OAuth {
 			 token__c, secret__c, isAccess__c FROM OAuth_Token__c 
 			 WHERE OAuth_Service__r.name= :serviceName AND owner__c=:userId AND isAccess__c = true];
 		} catch(System.QueryException e) {
-			message = 'User '+UserInfo.getUserName()+' did not authorize access to '+serviceName+'. Redirect user to authorization page. ['+e+']';
-			System.debug(message);
-			return false;
+			try {
+				// Two-legged OAuth - try to find match on serviceName
+				service = [SELECT id, name, consumer_key__c, consumer_secret__c 
+				 FROM OAuthService__c 
+				 WHERE name= :serviceName];
+				
+				System.debug('Preparing Two-legged OAuth request to service '+service.name);
+				
+				consumerKey = service.Consumer_Key__c;
+				consumerSecret = service.Consumer_Secret__c;
+				this.token = '';
+				tokenSecret = '';		
+				return true;
+			} catch(System.QueryException e1) {
+				message = 'Couldn\'t find service '+serviceName+'. ['+e1+']';
+				System.debug(message);
+				return false;
+			}
 		}
 		service = t.Oauth_Service__r;
 		

--- a/OAuth/src/classes/OAuth.cls
+++ b/OAuth/src/classes/OAuth.cls
@@ -221,8 +221,13 @@ public class OAuth {
 			System.debug('getUrlParams: '+s);
 			List<String> kv = s.split('=');
 			if(kv.size()>1) {
-				System.debug('getUrlParams:  -> '+kv[0]+','+kv[1]);
-				res.put(kv[0],kv[1]);
+			  // RFC 5849 section 3.4.1.3.1 and 3.4.1.3.2 specify that parameter names 
+			  // and values are decoded then encoded before being sorted and concatenated
+			  // Section 3.6 specifies that space must be encoded as %20 and not +
+			  String encName = EncodingUtil.urlEncode(EncodingUtil.urlDecode(kv[0], 'UTF-8'), 'UTF-8').replace('+','%20');
+			  String encValue = EncodingUtil.urlEncode(EncodingUtil.urlDecode(kv[1], 'UTF-8'), 'UTF-8').replace('+','%20');
+			  System.debug('getUrlParams:  -> '+encName+','+encValue);
+			  res.put(encName,encValue);
 			}
 		}
 		return res;


### PR DESCRIPTION
This pull request comprises a small number of commits I made to get the OAuth Playground working with services such as SimpleGeo. I fixed parameter encoding so that signatures worked correctly, added the '2 legged' OAuth use case for API integrations, and modified the OAuth class to be global so that it can be instantiated when the managed package is in use, allowing more interesting programmatic integrations.
